### PR TITLE
start pulling player's position from fleaflicker

### DIFF
--- a/app/controllers/team/indexcontroller.php
+++ b/app/controllers/team/indexcontroller.php
@@ -10,14 +10,13 @@ class IndexController
     {
         $id = $_GET["id"];
         $team = new Fleaflicker\Team($id);
-        $player_names = $team->getPlayers();
+        $players = $team->getPlayers();
         $team_name = $team->getTeamName();
         $owner = $team->getOwner();
 
-        $rankings = [];
         $ranking = new Models\Ranking();
-        foreach ($player_names as $player) {
-            $players[] = $ranking->getRecent($player);
+        for ($i = 0; $i < count($players); $i++) {
+            $players[$i]["ranking"] = $ranking->getRanking($players[$i]["name"]);
         }
 
         return compact("players", "team_name", "owner");

--- a/app/models/ranking.php
+++ b/app/models/ranking.php
@@ -17,15 +17,13 @@ class Ranking extends Models
         $this->db->exec($sql);
     }
 
-    public function getRecent($player)
+    public function getRanking($player_name)
     {
-        $sql = 'SELECT * FROM '.$this->table.' WHERE player like "%'.str_replace(" ", "%", $player).'%" ORDER BY updated_at DESC LIMIT 1';
+        $sql = 'SELECT ranking FROM '.$this->table.' WHERE player like "%'.str_replace(" ", "%", $player_name).'%" ORDER BY updated_at DESC LIMIT 1';
         foreach ($this->db->query($sql) as $row) {
                 $rank = $row["ranking"];
-                $position = $row["position"];
         }
-        return ["player" => $player,
-                "ranking" => (isset($rank) ? $rank : 'n/a'),
-                "position" => (isset($position) ? $position: 'n/a')];
+        
+        return isset($rank) ? $rank : 'n/a';
     }
 }

--- a/app/views/team/index.html
+++ b/app/views/team/index.html
@@ -10,7 +10,7 @@
   <tbody>
     <?php foreach ($data["players"] as $player): ?>
         <tr scope='row'>
-        <td><?= $player["player"]; ?></td>
+        <td><?= $player["name"]; ?></td>
         <td><?= $player["position"]; ?></td>
         <td><?= $player["ranking"]; ?></td>
         </tr>

--- a/lib/scraper/fleaflicker/team.php
+++ b/lib/scraper/fleaflicker/team.php
@@ -8,8 +8,9 @@ class Team extends Scraper
 {
     protected $cookie = '';
 
-    const XPATH_PLAYER_DATA = "//div[@class='player-name']/a";
-    const XPATH_NAME_DATA = "//div[@id='top-bar']/ul/li[3]";
+    const XPATH_PLAYER_NAME_DATA = "//div[@class='player-name']/a";
+    const XPATH_PLAYER_POS_DATA = "//div/span[@class='position']";
+    const XPATH_TEAM_NAME_DATA = "//div[@id='top-bar']/ul/li[3]";
     const XPATH_OWNER_DATA = "//a[@class='user-name']";
 
     public function __construct($team_id)
@@ -22,20 +23,42 @@ class Team extends Scraper
 
     public function getPlayers()
     {
+        $names = $this->getPlayerNames();
+        $positions = $this->getPlayerPositions();
+        for ($i = 0; $i < count($names); $i++) {
+            $players[] = ["name" => $names[$i], "position" => $positions[$i]];
+        }
+
+        return $players;
+    }
+
+    public function getPlayerNames()
+    {
         try {
-            $players = $this->getTextContent(self::XPATH_PLAYER_DATA);
+            $player_names = $this->getTextContent(self::XPATH_PLAYER_NAME_DATA);
         } catch (\Exception $e) {
             echo $e->getMessage();
             return;
         }
-        return $players;
+
+        return $player_names;
     }
 
+    private function getPlayerPositions()
+    {
+        try {
+            $positions = $this->getTextContent(self::XPATH_PLAYER_POS_DATA);
+        } catch (\Exception $e) {
+            echo $e->getMessage();
+            return;
+        }
+        return $positions;
+    }
 
     public function getTeamName()
     {
         try {
-            $name = $this->getTextContent(self::XPATH_NAME_DATA);
+            $name = $this->getTextContent(self::XPATH_TEAM_NAME_DATA);
         } catch (\Exception $e) {
             echo $e->getMessage();
             return;

--- a/tests/fleaflicker/teamtest.php
+++ b/tests/fleaflicker/teamtest.php
@@ -5,7 +5,7 @@ $_SESSION["env"] = "dev";
 
 use Lib\Scraper\Fleaflicker;
 
-class TeamTests extends \PHPUnit_Framework_TestCase
+class TeamTests extends \PHPUnit\Framework\TestCase
 {
     private $team;
 
@@ -23,8 +23,9 @@ class TeamTests extends \PHPUnit_Framework_TestCase
         $players = $this->team->getPlayers();
         $this->assertGreaterThan(0, count($players), "does not return array");
         foreach ($players as $player) {
-            $this->assertTrue(is_string($player), "does not return a string");
-            $this->assertContains(" ", $player, "does not return a first/last name with space");
+            $this->assertTrue(is_string($player["name"]), "name - does not return a string");
+            $this->assertContains(" ", $player["name"], "does not return a first/last name with space");
+            $this->assertTrue(is_string($player["position"]), "position - does not return a string");
         }
     }
 }


### PR DESCRIPTION
Previously, the position was being pulled from DLF, but some players wereren't being ranked so their position could not be pulled. These changes pull the position from Fleaflicker instead.

Also updating `getRecent()` to `getRanking()` and only pulling rank, since we no longer need position.